### PR TITLE
fix issue as comparing component version

### DIFF
--- a/exploit/components.pl
+++ b/exploit/components.pl
@@ -62,7 +62,7 @@ while( my $row = <$DB>)  {
 							 $tmp.="$comversion\n";
 								 $a=$comversion;
 								 $b=@matches[6];
-								 	if(!&version_compare("$a","$b") == 1) {
+								 	if(&version_compare("$a","$b") == -1) {
 
 								 		$tmp.= "[!] We found vulnerable component\n";
 									 }else{


### PR DESCRIPTION
According to components.pl at line 90, matches[6] is fixed version.
So vulnerable version is less than matches[6].
But now reported as vulnerable version even if same as matches[6].