### PR TITLE
Fixed enumerate components and core joomla vulnerability outputs

### DIFF
--- a/exploit/components.pl
+++ b/exploit/components.pl
@@ -6,7 +6,7 @@ $btf=0;
 
 $ua->requests_redirectable(undef);
 
-open(my $DB,"exploit/db/componentslist.txt");
+open(my $DB,"$mepath/exploit/db/componentslist.txt");
 while( my $row = <$DB>)  {
 	chomp $row;
 

--- a/exploit/verexploit.pl
+++ b/exploit/verexploit.pl
@@ -1,6 +1,6 @@
 #start 
 dprint("Core Joomla Vulnerability");
-open(my $DB,"exploit/db/corevul.txt");
+open(my $DB,"$mepath/exploit/db/corevul.txt");
 my $vver=substr($ver, index($ver, ' ')+1, 6);
 $vver =~ s/ //g;
 while( my $row = <$DB>)  {


### PR DESCRIPTION
Fixed:
        1.Core Joomla Vulnerability outputs always "not vulnerable" and
	2.Enumeration component doesn't find components when joomscan is executed in a different path rather than inside joomscan/ folder.

Eg. Executing "perl joomscan.pl -u XX.XX.XX.XX -ec", enumerates components correctly, and core vulnerabilities are found, whilst executing the same command but outside the folder("cd .." and then execute) "perl folder/joomscan.pl -u XX.XX.XX.XX -ec" doesn't show the same results as above.