### PR TITLE
Fix bug in version finder of the components

### DIFF
--- a/exploit/components.pl
+++ b/exploit/components.pl
@@ -44,7 +44,7 @@ while( my $row = <$DB>)  {
 		$sourcer=$response->decoded_content;
 		if ($response->status_line =~ /200/g ) {
 			$sourcer =~ /type=\"component\" version=\"(.*?)\"/;
-			my $comversion = $1;
+			$comversion = $1;
 			$tmp.="Installed version : $comversion\n";
 			
 				}


### PR DESCRIPTION
The comparison between installed version found by joomscan and the vulnerable version is incorrect due to the scope of the variable `$comversion`.